### PR TITLE
Spectator Modus

### DIFF
--- a/ai_wars/server/game_class.py
+++ b/ai_wars/server/game_class.py
@@ -35,6 +35,7 @@ class GameClass:
 	spaceship_image = load_sprite("ai_wars/img/spaceship.png", True)
 	bullet_image = load_sprite("ai_wars/img/bullet.png", True)
 
+
 	def __init__(self, addr: str, port: int):
 		pygame.init()
 		self.clock = pygame.time.Clock()
@@ -88,6 +89,9 @@ class GameClass:
 			try:
 				received_action = self.server.recv_next()
 				name, actions = deserialize_action(received_action)
+
+				if name == "spectator":
+					continue
 
 				# spawn spaceship at random position if necessary
 				if name not in self.spaceships:

--- a/client.py
+++ b/client.py
@@ -1,4 +1,5 @@
 """main hook to start the game"""
+import sys
 import argparse
 import logging
 from ai_wars.client.player import Player
@@ -8,14 +9,25 @@ from ai_wars.client.game_gui import GameGUI
 if __name__ == "__main__":
 	parser = argparse.ArgumentParser()
 	parser.add_argument("--name", "-n", help="specify the player name to connect with",
-	                    type=str, required=True)
+						type=str)
+	parser.add_argument("--spectate", help="enter the spectate mode", action="store_true")
 	parser.add_argument("--port", "-p", help="specify port on which the client connects",
-                     type=int, default=1337)
+						type=int, default=1337)
 	parser.add_argument("--addr", "-a", help="specify the network addr. on which the client connects",
-	                    type=str, default="127.0.0.1")
+						type=str, default="127.0.0.1")
 	parser.add_argument("--verbose", "-l", help="enable logging mode for the client",
-	                    action="store_true", default=False)
+						action="store_true", default=False)
 	args = parser.parse_args()
+
+	if args.name is None and not args.spectate:
+		print("Error: Either --name <name> or --spectate must be specified!")
+		sys.exit(0)
+
+	if args.name is not None and args.spectate:
+		print("Error: Arguments --name <name> and --spectate may not specified at the same time!")
+		sys.exit(0)
+
+	player_name = "spectator" if args.spectate else args.name
 
 	if args.verbose:
 		logging.basicConfig(level=logging.DEBUG,
@@ -26,5 +38,5 @@ if __name__ == "__main__":
 						format="%(asctime)-8s %(levelname)-8s %(message)s",
 						datefmt="%H:%M:%S")
 
-	player = Player(args.name, args.addr, args.port, GameGUI())
+	player = Player(player_name, args.addr, args.port, GameGUI())
 	player.loop()


### PR DESCRIPTION
Einfach wenn der Spielername `spectator` ist, wird keine Raumschiff erzeugt und die Inputs werden ignoriert.

Kann einfach mit `python3 client.py --spectate` gestartet werden.